### PR TITLE
Added thread_safe caching

### DIFF
--- a/lib/tairu/cache/memory.rb
+++ b/lib/tairu/cache/memory.rb
@@ -1,8 +1,10 @@
+require 'thread_safe'
+
 module Tairu
   module Cache
     class Memory
       def initialize(options=nil)
-        @tiles = {}
+        @tiles = ThreadSafe::Cache.new
       end
 
       def add(name, coord, tile, age=300)
@@ -27,8 +29,15 @@ module Tairu
       end
 
       def purge_expired
-        @tiles.delete_if {|k,v| v[:expire] > Time.now}
+        # @tiles.delete_if {|k,v| v[:expire] > Time.now}
+        # delete_if is not supported in the thread_safe cache
+        @tiles.each_pair do |k,v|
+          if v[:expire] > Time.now
+            @tiles.delete(k)
+          end
+        end
       end
+      
     end
   end
 end

--- a/tairu.gemspec
+++ b/tairu.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'redis', '>= 3.0.4'
   gem.add_runtime_dependency 'connection_pool', '>= 1.1.0'
   gem.add_runtime_dependency 'multi_json', '>= 1.7.6'
+  gem.add_runtime_dependency 'thread_safe', '>= 0.3.5'
   gem.add_runtime_dependency 'sinatra', '>= 1.4.3'
   gem.add_runtime_dependency 'puma', '>= 2.0.1'
 


### PR DESCRIPTION
Ruby hashes are not thread safe and tairu runs in 4 threads on Puma by default. We were seeing runtime errors and tiles being dropped under moderate load. Switched to thread_safe gem’s version of a cache to prevent this problem.
